### PR TITLE
Update for Terraform 0.12

### DIFF
--- a/examples/advanced-ecdsa/main.tf
+++ b/examples/advanced-ecdsa/main.tf
@@ -2,15 +2,16 @@ module "tls_self_signed_cert" {
   # source = "github.com/hashicorp-modules/tls-self-signed-cert"
   source = "../../../tls-self-signed-cert"
 
-  create                = "${var.create}"
-  name                  = "${var.name}"
-  algorithm             = "${var.algorithm}"
-  ecdsa_curve           = "${var.ecdsa_curve}"
-  validity_period_hours = "${var.validity_period_hours}"
-  ca_common_name        = "${var.ca_common_name}"
-  organization_name     = "${var.organization_name}"
-  common_name           = "${var.common_name}"
-  dns_names             = "${var.dns_names}"
-  ip_addresses          = "${var.ip_addresses}"
+  create                = var.create
+  name                  = var.name
+  algorithm             = var.algorithm
+  ecdsa_curve           = var.ecdsa_curve
+  validity_period_hours = var.validity_period_hours
+  ca_common_name        = var.ca_common_name
+  organization_name     = var.organization_name
+  common_name           = var.common_name
+  dns_names             = var.dns_names
+  ip_addresses          = var.ip_addresses
   download_certs        = true
 }
+

--- a/examples/advanced-ecdsa/outputs.tf
+++ b/examples/advanced-ecdsa/outputs.tf
@@ -10,85 +10,87 @@ output "zREADME" {
 
 ${module.tls_self_signed_cert.zREADME}
 README
+
 }
 
 output "algorithm" {
-  value = "${var.algorithm}"
+  value = var.algorithm
 }
 
 # CA - TLS private key
 output "ca_private_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_private_key_pem}"
+  value = module.tls_self_signed_cert.ca_private_key_pem
 }
 
 output "ca_public_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_public_key_pem}"
+  value = module.tls_self_signed_cert.ca_public_key_pem
 }
 
 output "ca_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.ca_public_key_openssh}"
+  value = module.tls_self_signed_cert.ca_public_key_openssh
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name" {
-  value = "${module.tls_self_signed_cert.ca_cert_name}"
+  value = module.tls_self_signed_cert.ca_cert_name
 }
 
 output "ca_cert_filename" {
-  value = "${module.tls_self_signed_cert.ca_cert_filename}"
+  value = module.tls_self_signed_cert.ca_cert_filename
 }
 
 output "ca_cert_pem" {
-  value = "${module.tls_self_signed_cert.ca_cert_pem}"
+  value = module.tls_self_signed_cert.ca_cert_pem
 }
 
 output "ca_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_start_time
 }
 
 output "ca_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_end_time
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_pem}"
+  value = module.tls_self_signed_cert.leaf_private_key_pem
 }
 
 output "leaf_private_key_filename" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_filename}"
+  value = module.tls_self_signed_cert.leaf_private_key_filename
 }
 
 output "leaf_public_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_pem}"
+  value = module.tls_self_signed_cert.leaf_public_key_pem
 }
 
 output "leaf_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_openssh}"
+  value = module.tls_self_signed_cert.leaf_public_key_openssh
 }
 
 # Leaf - TLS cert request
 output "leaf_cert_request_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_request_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_request_pem
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name" {
-  value = "${module.tls_self_signed_cert.leaf_cert_name}"
+  value = module.tls_self_signed_cert.leaf_cert_name
 }
 
 output "leaf_cert_filename" {
-  value = "${module.tls_self_signed_cert.leaf_cert_filename}"
+  value = module.tls_self_signed_cert.leaf_cert_filename
 }
 
 output "leaf_cert_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_pem
 }
 
 output "leaf_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_start_time
 }
 
 output "leaf_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_end_time
 }
+

--- a/examples/advanced-ecdsa/terraform.tfvars
+++ b/examples/advanced-ecdsa/terraform.tfvars
@@ -6,5 +6,5 @@ validity_period_hours = "48"
 ca_common_name        = "advanced-ecdsa.com"
 organization_name     = "Advanced ECDSA Inc."
 common_name           = "advanced-ecdsa.com"
-dns_names             = ["foo.advanced-ecdsa.com", "bar.advanced-ecdsa.com",]
-ip_addresses          = ["127.0.0.1", "0.0.0.0",]
+dns_names             = ["foo.advanced-ecdsa.com", "bar.advanced-ecdsa.com", ]
+ip_addresses          = ["127.0.0.1", "0.0.0.0", ]

--- a/examples/advanced-ecdsa/variables.tf
+++ b/examples/advanced-ecdsa/variables.tf
@@ -1,10 +1,32 @@
-variable "create"                { }
-variable "name"                  { }
-variable "algorithm"             { }
-variable "ecdsa_curve"           { }
-variable "validity_period_hours" { }
-variable "ca_common_name"        { }
-variable "organization_name"     { }
-variable "common_name"           { }
-variable "dns_names"             { type = "list" }
-variable "ip_addresses"          { type = "list" }
+variable "create" {
+}
+
+variable "name" {
+}
+
+variable "algorithm" {
+}
+
+variable "ecdsa_curve" {
+}
+
+variable "validity_period_hours" {
+}
+
+variable "ca_common_name" {
+}
+
+variable "organization_name" {
+}
+
+variable "common_name" {
+}
+
+variable "dns_names" {
+  type = list(string)
+}
+
+variable "ip_addresses" {
+  type = list(string)
+}
+

--- a/examples/advanced-ecdsa/versions.tf
+++ b/examples/advanced-ecdsa/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/advanced-rsa/main.tf
+++ b/examples/advanced-rsa/main.tf
@@ -2,15 +2,16 @@ module "tls_self_signed_cert" {
   # source = "github.com/hashicorp-modules/tls-self-signed-cert"
   source = "../../../tls-self-signed-cert"
 
-  create                = "${var.create}"
-  name                  = "${var.name}"
-  algorithm             = "${var.algorithm}"
-  rsa_bits              = "${var.rsa_bits}"
-  validity_period_hours = "${var.validity_period_hours}"
-  ca_common_name        = "${var.ca_common_name}"
-  organization_name     = "${var.organization_name}"
-  common_name           = "${var.common_name}"
-  dns_names             = "${var.dns_names}"
-  ip_addresses          = "${var.ip_addresses}"
+  create                = var.create
+  name                  = var.name
+  algorithm             = var.algorithm
+  rsa_bits              = var.rsa_bits
+  validity_period_hours = var.validity_period_hours
+  ca_common_name        = var.ca_common_name
+  organization_name     = var.organization_name
+  common_name           = var.common_name
+  dns_names             = var.dns_names
+  ip_addresses          = var.ip_addresses
   download_certs        = true
 }
+

--- a/examples/advanced-rsa/outputs.tf
+++ b/examples/advanced-rsa/outputs.tf
@@ -10,85 +10,87 @@ output "zREADME" {
 
 ${module.tls_self_signed_cert.zREADME}
 README
+
 }
 
 output "algorithm" {
-  value = "${var.algorithm}"
+  value = var.algorithm
 }
 
 # CA - TLS private key
 output "ca_private_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_private_key_pem}"
+  value = module.tls_self_signed_cert.ca_private_key_pem
 }
 
 output "ca_public_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_public_key_pem}"
+  value = module.tls_self_signed_cert.ca_public_key_pem
 }
 
 output "ca_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.ca_public_key_openssh}"
+  value = module.tls_self_signed_cert.ca_public_key_openssh
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name" {
-  value = "${module.tls_self_signed_cert.ca_cert_name}"
+  value = module.tls_self_signed_cert.ca_cert_name
 }
 
 output "ca_cert_filename" {
-  value = "${module.tls_self_signed_cert.ca_cert_filename}"
+  value = module.tls_self_signed_cert.ca_cert_filename
 }
 
 output "ca_cert_pem" {
-  value = "${module.tls_self_signed_cert.ca_cert_pem}"
+  value = module.tls_self_signed_cert.ca_cert_pem
 }
 
 output "ca_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_start_time
 }
 
 output "ca_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_end_time
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_pem}"
+  value = module.tls_self_signed_cert.leaf_private_key_pem
 }
 
 output "leaf_private_key_filename" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_filename}"
+  value = module.tls_self_signed_cert.leaf_private_key_filename
 }
 
 output "leaf_public_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_pem}"
+  value = module.tls_self_signed_cert.leaf_public_key_pem
 }
 
 output "leaf_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_openssh}"
+  value = module.tls_self_signed_cert.leaf_public_key_openssh
 }
 
 # Leaf - TLS cert request
 output "leaf_cert_request_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_request_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_request_pem
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name" {
-  value = "${module.tls_self_signed_cert.leaf_cert_name}"
+  value = module.tls_self_signed_cert.leaf_cert_name
 }
 
 output "leaf_cert_filename" {
-  value = "${module.tls_self_signed_cert.leaf_cert_filename}"
+  value = module.tls_self_signed_cert.leaf_cert_filename
 }
 
 output "leaf_cert_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_pem
 }
 
 output "leaf_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_start_time
 }
 
 output "leaf_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_end_time
 }
+

--- a/examples/advanced-rsa/terraform.tfvars
+++ b/examples/advanced-rsa/terraform.tfvars
@@ -6,5 +6,5 @@ validity_period_hours = "36"
 ca_common_name        = "advanced-rsa.com"
 organization_name     = "Advanced RSA Inc."
 common_name           = "advanced-rsa.com"
-dns_names             = ["foo.advanced-rsa.com", "bar.advanced-rsa.com",]
-ip_addresses          = ["127.0.0.1", "0.0.0.0",]
+dns_names             = ["foo.advanced-rsa.com", "bar.advanced-rsa.com", ]
+ip_addresses          = ["127.0.0.1", "0.0.0.0", ]

--- a/examples/advanced-rsa/variables.tf
+++ b/examples/advanced-rsa/variables.tf
@@ -1,10 +1,32 @@
-variable "create"                { }
-variable "name"                  { }
-variable "algorithm"             { }
-variable "rsa_bits"              { }
-variable "validity_period_hours" { }
-variable "ca_common_name"        { }
-variable "organization_name"     { }
-variable "common_name"           { }
-variable "dns_names"             { type = "list" }
-variable "ip_addresses"          { type = "list" }
+variable "create" {
+}
+
+variable "name" {
+}
+
+variable "algorithm" {
+}
+
+variable "rsa_bits" {
+}
+
+variable "validity_period_hours" {
+}
+
+variable "ca_common_name" {
+}
+
+variable "organization_name" {
+}
+
+variable "common_name" {
+}
+
+variable "dns_names" {
+  type = list(string)
+}
+
+variable "ip_addresses" {
+  type = list(string)
+}
+

--- a/examples/advanced-rsa/versions.tf
+++ b/examples/advanced-rsa/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/ca-override/main.tf
+++ b/examples/ca-override/main.tf
@@ -2,16 +2,16 @@ module "tls_self_signed_cert" {
   # source = "github.com/hashicorp-modules/tls-self-signed-cert"
   source = "../../../tls-self-signed-cert"
 
-  create                = "${var.create}"
-  name                  = "${var.name}"
-  algorithm             = "${var.algorithm}"
-  rsa_bits              = "${var.rsa_bits}"
-  validity_period_hours = "${var.validity_period_hours}"
-  ca_common_name        = "${var.ca_common_name}"
-  organization_name     = "${var.organization_name}"
-  common_name           = "${var.common_name}"
-  dns_names             = "${var.dns_names}"
-  ip_addresses          = "${var.ip_addresses}"
+  create                = var.create
+  name                  = var.name
+  algorithm             = var.algorithm
+  rsa_bits              = var.rsa_bits
+  validity_period_hours = var.validity_period_hours
+  ca_common_name        = var.ca_common_name
+  organization_name     = var.organization_name
+  common_name           = var.common_name
+  dns_names             = var.dns_names
+  ip_addresses          = var.ip_addresses
   download_certs        = true
 }
 
@@ -19,19 +19,20 @@ module "tls_self_signed_cert_override" {
   # source = "github.com/hashicorp-modules/tls-self-signed-cert"
   source = "../../../tls-self-signed-cert"
 
-  create                = "${var.create}"
+  create                = var.create
   name                  = "${var.name}-override"
-  algorithm             = "${var.algorithm}"
-  rsa_bits              = "${var.rsa_bits}"
-  validity_period_hours = "${var.validity_period_hours}"
-  ca_common_name        = "${var.ca_common_name}"
-  organization_name     = "${var.organization_name}"
-  common_name           = "${var.common_name}"
-  dns_names             = "${var.dns_names}"
-  ip_addresses          = "${var.ip_addresses}"
+  algorithm             = var.algorithm
+  rsa_bits              = var.rsa_bits
+  validity_period_hours = var.validity_period_hours
+  ca_common_name        = var.ca_common_name
+  organization_name     = var.organization_name
+  common_name           = var.common_name
+  dns_names             = var.dns_names
+  ip_addresses          = var.ip_addresses
   download_certs        = true
 
   ca_override      = true
-  ca_key_override  = "${module.tls_self_signed_cert.ca_private_key_pem}"
-  ca_cert_override = "${module.tls_self_signed_cert.ca_cert_pem}"
+  ca_key_override  = module.tls_self_signed_cert.ca_private_key_pem
+  ca_cert_override = module.tls_self_signed_cert.ca_cert_pem
 }
+

--- a/examples/ca-override/outputs.tf
+++ b/examples/ca-override/outputs.tf
@@ -9,163 +9,165 @@ output "zREADME" {
 
 ${module.tls_self_signed_cert.zREADME}${module.tls_self_signed_cert_override.zREADME}
 README
+
 }
 
 output "algorithm" {
-  value = "${var.algorithm}"
+  value = var.algorithm
 }
 
 # CA - TLS private key
 output "ca_private_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_private_key_pem}"
+  value = module.tls_self_signed_cert.ca_private_key_pem
 }
 
 output "ca_public_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_public_key_pem}"
+  value = module.tls_self_signed_cert.ca_public_key_pem
 }
 
 output "ca_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.ca_public_key_openssh}"
+  value = module.tls_self_signed_cert.ca_public_key_openssh
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name" {
-  value = "${module.tls_self_signed_cert.ca_cert_name}"
+  value = module.tls_self_signed_cert.ca_cert_name
 }
 
 output "ca_cert_filename" {
-  value = "${module.tls_self_signed_cert.ca_cert_filename}"
+  value = module.tls_self_signed_cert.ca_cert_filename
 }
 
 output "ca_cert_pem" {
-  value = "${module.tls_self_signed_cert.ca_cert_pem}"
+  value = module.tls_self_signed_cert.ca_cert_pem
 }
 
 output "ca_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_start_time
 }
 
 output "ca_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_end_time
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_pem}"
+  value = module.tls_self_signed_cert.leaf_private_key_pem
 }
 
 output "leaf_private_key_filename" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_filename}"
+  value = module.tls_self_signed_cert.leaf_private_key_filename
 }
 
 output "leaf_public_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_pem}"
+  value = module.tls_self_signed_cert.leaf_public_key_pem
 }
 
 output "leaf_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_openssh}"
+  value = module.tls_self_signed_cert.leaf_public_key_openssh
 }
 
 # Leaf - TLS cert request
 output "leaf_cert_request_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_request_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_request_pem
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name" {
-  value = "${module.tls_self_signed_cert.leaf_cert_name}"
+  value = module.tls_self_signed_cert.leaf_cert_name
 }
 
 output "leaf_cert_filename" {
-  value = "${module.tls_self_signed_cert.leaf_cert_filename}"
+  value = module.tls_self_signed_cert.leaf_cert_filename
 }
 
 output "leaf_cert_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_pem
 }
 
 output "leaf_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_start_time
 }
 
 output "leaf_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_end_time
 }
 
 ## Override
 # CA - TLS private key
 output "ca_private_key_pem_override" {
-  value = "${module.tls_self_signed_cert_override.ca_private_key_pem}"
+  value = module.tls_self_signed_cert_override.ca_private_key_pem
 }
 
 output "ca_public_key_pem_override" {
-  value = "${module.tls_self_signed_cert_override.ca_public_key_pem}"
+  value = module.tls_self_signed_cert_override.ca_public_key_pem
 }
 
 output "ca_public_key_openssh_override" {
-  value = "${module.tls_self_signed_cert_override.ca_public_key_openssh}"
+  value = module.tls_self_signed_cert_override.ca_public_key_openssh
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name_override" {
-  value = "${module.tls_self_signed_cert_override.ca_cert_name}"
+  value = module.tls_self_signed_cert_override.ca_cert_name
 }
 
 output "ca_cert_filename_override" {
-  value = "${module.tls_self_signed_cert_override.ca_cert_filename}"
+  value = module.tls_self_signed_cert_override.ca_cert_filename
 }
 
 output "ca_cert_pem_override" {
-  value = "${module.tls_self_signed_cert_override.ca_cert_pem}"
+  value = module.tls_self_signed_cert_override.ca_cert_pem
 }
 
 output "ca_cert_validity_start_time_override" {
-  value = "${module.tls_self_signed_cert_override.ca_cert_validity_start_time}"
+  value = module.tls_self_signed_cert_override.ca_cert_validity_start_time
 }
 
 output "ca_cert_validity_end_time_override" {
-  value = "${module.tls_self_signed_cert_override.ca_cert_validity_end_time}"
+  value = module.tls_self_signed_cert_override.ca_cert_validity_end_time
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_private_key_pem}"
+  value = module.tls_self_signed_cert_override.leaf_private_key_pem
 }
 
 output "leaf_private_key_filename_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_private_key_filename}"
+  value = module.tls_self_signed_cert_override.leaf_private_key_filename
 }
 
 output "leaf_public_key_pem_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_public_key_pem}"
+  value = module.tls_self_signed_cert_override.leaf_public_key_pem
 }
 
 output "leaf_public_key_openssh_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_public_key_openssh}"
+  value = module.tls_self_signed_cert_override.leaf_public_key_openssh
 }
 
 # Leaf - TLS cert request
 output "leaf_cert_request_pem_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_cert_request_pem}"
+  value = module.tls_self_signed_cert_override.leaf_cert_request_pem
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_cert_name}"
+  value = module.tls_self_signed_cert_override.leaf_cert_name
 }
 
 output "leaf_cert_filename_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_cert_filename}"
+  value = module.tls_self_signed_cert_override.leaf_cert_filename
 }
 
 output "leaf_cert_pem_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_cert_pem}"
+  value = module.tls_self_signed_cert_override.leaf_cert_pem
 }
 
 output "leaf_cert_validity_start_time_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_cert_validity_start_time}"
+  value = module.tls_self_signed_cert_override.leaf_cert_validity_start_time
 }
 
 output "leaf_cert_validity_end_time_override" {
-  value = "${module.tls_self_signed_cert_override.leaf_cert_validity_end_time}"
+  value = module.tls_self_signed_cert_override.leaf_cert_validity_end_time
 }
+

--- a/examples/ca-override/terraform.tfvars
+++ b/examples/ca-override/terraform.tfvars
@@ -6,5 +6,5 @@ validity_period_hours = "36"
 ca_common_name        = "advanced-rsa.com"
 organization_name     = "Advanced RSA Inc."
 common_name           = "advanced-rsa.com"
-dns_names             = ["foo.advanced-rsa.com", "bar.advanced-rsa.com", "localhost",]
-ip_addresses          = ["127.0.0.1", "0.0.0.0",]
+dns_names             = ["foo.advanced-rsa.com", "bar.advanced-rsa.com", "localhost", ]
+ip_addresses          = ["127.0.0.1", "0.0.0.0", ]

--- a/examples/ca-override/variables.tf
+++ b/examples/ca-override/variables.tf
@@ -1,10 +1,32 @@
-variable "create"                { }
-variable "name"                  { }
-variable "algorithm"             { }
-variable "rsa_bits"              { }
-variable "validity_period_hours" { }
-variable "ca_common_name"        { }
-variable "organization_name"     { }
-variable "common_name"           { }
-variable "dns_names"             { type = "list" }
-variable "ip_addresses"          { type = "list" }
+variable "create" {
+}
+
+variable "name" {
+}
+
+variable "algorithm" {
+}
+
+variable "rsa_bits" {
+}
+
+variable "validity_period_hours" {
+}
+
+variable "ca_common_name" {
+}
+
+variable "organization_name" {
+}
+
+variable "common_name" {
+}
+
+variable "dns_names" {
+  type = list(string)
+}
+
+variable "ip_addresses" {
+  type = list(string)
+}
+

--- a/examples/ca-override/versions.tf
+++ b/examples/ca-override/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/no-provision/main.tf
+++ b/examples/no-provision/main.tf
@@ -11,3 +11,4 @@ module "tls_self_signed_cert" {
   dns_names             = [""]
   ip_addresses          = [""]
 }
+

--- a/examples/no-provision/outputs.tf
+++ b/examples/no-provision/outputs.tf
@@ -2,4 +2,6 @@ output "zREADME" {
   value = <<README
 No resources to provision.
 README
+
 }
+

--- a/examples/no-provision/terraform.tfvars
+++ b/examples/no-provision/terraform.tfvars
@@ -3,5 +3,5 @@ validity_period_hours = "12"
 ca_common_name        = "simple.com"
 organization_name     = "Simple Inc."
 common_name           = "simple.co cert"
-dns_names             = ["simple.example.com",]
-ip_addresses          = ["127.0.0.1", "0.0.0.0",]
+dns_names             = ["simple.example.com", ]
+ip_addresses          = ["127.0.0.1", "0.0.0.0", ]

--- a/examples/no-provision/variables.tf
+++ b/examples/no-provision/variables.tf
@@ -1,7 +1,23 @@
-variable "name"                  { }
-variable "validity_period_hours" { }
-variable "ca_common_name"        { }
-variable "organization_name"     { }
-variable "common_name"           { }
-variable "dns_names"             { type = "list" }
-variable "ip_addresses"          { type = "list" }
+variable "name" {
+}
+
+variable "validity_period_hours" {
+}
+
+variable "ca_common_name" {
+}
+
+variable "organization_name" {
+}
+
+variable "common_name" {
+}
+
+variable "dns_names" {
+  type = list(string)
+}
+
+variable "ip_addresses" {
+  type = list(string)
+}
+

--- a/examples/no-provision/versions.tf
+++ b/examples/no-provision/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/simple-ecdsa/main.tf
+++ b/examples/simple-ecdsa/main.tf
@@ -2,13 +2,14 @@ module "tls_self_signed_cert" {
   # source = "github.com/hashicorp-modules/tls-self-signed-cert"
   source = "../../../tls-self-signed-cert"
 
-  name                  = "${var.name}"
-  algorithm             = "${var.algorithm}"
-  validity_period_hours = "${var.validity_period_hours}"
-  ca_common_name        = "${var.ca_common_name}"
-  organization_name     = "${var.organization_name}"
-  common_name           = "${var.common_name}"
-  dns_names             = "${var.dns_names}"
-  ip_addresses          = "${var.ip_addresses}"
+  name                  = var.name
+  algorithm             = var.algorithm
+  validity_period_hours = var.validity_period_hours
+  ca_common_name        = var.ca_common_name
+  organization_name     = var.organization_name
+  common_name           = var.common_name
+  dns_names             = var.dns_names
+  ip_addresses          = var.ip_addresses
   download_certs        = true
 }
+

--- a/examples/simple-ecdsa/outputs.tf
+++ b/examples/simple-ecdsa/outputs.tf
@@ -10,81 +10,83 @@ output "zREADME" {
 
 ${module.tls_self_signed_cert.zREADME}
 README
+
 }
 
 # CA - TLS private key
 output "ca_private_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_private_key_pem}"
+  value = module.tls_self_signed_cert.ca_private_key_pem
 }
 
 output "ca_public_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_public_key_pem}"
+  value = module.tls_self_signed_cert.ca_public_key_pem
 }
 
 output "ca_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.ca_public_key_openssh}"
+  value = module.tls_self_signed_cert.ca_public_key_openssh
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name" {
-  value = "${module.tls_self_signed_cert.ca_cert_name}"
+  value = module.tls_self_signed_cert.ca_cert_name
 }
 
 output "ca_cert_filename" {
-  value = "${module.tls_self_signed_cert.ca_cert_filename}"
+  value = module.tls_self_signed_cert.ca_cert_filename
 }
 
 output "ca_cert_pem" {
-  value = "${module.tls_self_signed_cert.ca_cert_pem}"
+  value = module.tls_self_signed_cert.ca_cert_pem
 }
 
 output "ca_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_start_time
 }
 
 output "ca_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_end_time
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_pem}"
+  value = module.tls_self_signed_cert.leaf_private_key_pem
 }
 
 output "leaf_private_key_filename" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_filename}"
+  value = module.tls_self_signed_cert.leaf_private_key_filename
 }
 
 output "leaf_public_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_pem}"
+  value = module.tls_self_signed_cert.leaf_public_key_pem
 }
 
 output "leaf_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_openssh}"
+  value = module.tls_self_signed_cert.leaf_public_key_openssh
 }
 
 # Leaf - TLS cert request
 output "leaf_cert_request_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_request_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_request_pem
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name" {
-  value = "${module.tls_self_signed_cert.leaf_cert_name}"
+  value = module.tls_self_signed_cert.leaf_cert_name
 }
 
 output "leaf_cert_filename" {
-  value = "${module.tls_self_signed_cert.leaf_cert_filename}"
+  value = module.tls_self_signed_cert.leaf_cert_filename
 }
 
 output "leaf_cert_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_pem
 }
 
 output "leaf_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_start_time
 }
 
 output "leaf_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_end_time
 }
+

--- a/examples/simple-ecdsa/terraform.tfvars
+++ b/examples/simple-ecdsa/terraform.tfvars
@@ -4,5 +4,5 @@ validity_period_hours = "24"
 ca_common_name        = "simple-ecdsa.com"
 organization_name     = "Simple ECDSA Inc."
 common_name           = "simple-ecdsa.com"
-dns_names             = ["foo.simple-ecdsa.com",]
-ip_addresses          = ["127.0.0.1",]
+dns_names             = ["foo.simple-ecdsa.com", ]
+ip_addresses          = ["127.0.0.1", ]

--- a/examples/simple-ecdsa/variables.tf
+++ b/examples/simple-ecdsa/variables.tf
@@ -1,8 +1,26 @@
-variable "name"                  { }
-variable "algorithm"             { }
-variable "validity_period_hours" { }
-variable "ca_common_name"        { }
-variable "organization_name"     { }
-variable "common_name"           { }
-variable "dns_names"             { type = "list" }
-variable "ip_addresses"          { type = "list" }
+variable "name" {
+}
+
+variable "algorithm" {
+}
+
+variable "validity_period_hours" {
+}
+
+variable "ca_common_name" {
+}
+
+variable "organization_name" {
+}
+
+variable "common_name" {
+}
+
+variable "dns_names" {
+  type = list(string)
+}
+
+variable "ip_addresses" {
+  type = list(string)
+}
+

--- a/examples/simple-ecdsa/versions.tf
+++ b/examples/simple-ecdsa/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/simple-rsa/main.tf
+++ b/examples/simple-rsa/main.tf
@@ -2,12 +2,13 @@ module "tls_self_signed_cert" {
   # source = "github.com/hashicorp-modules/tls-self-signed-cert"
   source = "../../../tls-self-signed-cert"
 
-  name                  = "${var.name}"
-  validity_period_hours = "${var.validity_period_hours}"
-  ca_common_name        = "${var.ca_common_name}"
-  organization_name     = "${var.organization_name}"
-  common_name           = "${var.common_name}"
-  dns_names             = "${var.dns_names}"
-  ip_addresses          = "${var.ip_addresses}"
+  name                  = var.name
+  validity_period_hours = var.validity_period_hours
+  ca_common_name        = var.ca_common_name
+  organization_name     = var.organization_name
+  common_name           = var.common_name
+  dns_names             = var.dns_names
+  ip_addresses          = var.ip_addresses
   download_certs        = true
 }
+

--- a/examples/simple-rsa/outputs.tf
+++ b/examples/simple-rsa/outputs.tf
@@ -10,81 +10,83 @@ output "zREADME" {
 
 ${module.tls_self_signed_cert.zREADME}
 README
+
 }
 
 # CA - TLS private key
 output "ca_private_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_private_key_pem}"
+  value = module.tls_self_signed_cert.ca_private_key_pem
 }
 
 output "ca_public_key_pem" {
-  value = "${module.tls_self_signed_cert.ca_public_key_pem}"
+  value = module.tls_self_signed_cert.ca_public_key_pem
 }
 
 output "ca_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.ca_public_key_openssh}"
+  value = module.tls_self_signed_cert.ca_public_key_openssh
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name" {
-  value = "${module.tls_self_signed_cert.ca_cert_name}"
+  value = module.tls_self_signed_cert.ca_cert_name
 }
 
 output "ca_cert_filename" {
-  value = "${module.tls_self_signed_cert.ca_cert_filename}"
+  value = module.tls_self_signed_cert.ca_cert_filename
 }
 
 output "ca_cert_pem" {
-  value = "${module.tls_self_signed_cert.ca_cert_pem}"
+  value = module.tls_self_signed_cert.ca_cert_pem
 }
 
 output "ca_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_start_time
 }
 
 output "ca_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.ca_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.ca_cert_validity_end_time
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_pem}"
+  value = module.tls_self_signed_cert.leaf_private_key_pem
 }
 
 output "leaf_private_key_filename" {
-  value = "${module.tls_self_signed_cert.leaf_private_key_filename}"
+  value = module.tls_self_signed_cert.leaf_private_key_filename
 }
 
 output "leaf_public_key_pem" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_pem}"
+  value = module.tls_self_signed_cert.leaf_public_key_pem
 }
 
 output "leaf_public_key_openssh" {
-  value = "${module.tls_self_signed_cert.leaf_public_key_openssh}"
+  value = module.tls_self_signed_cert.leaf_public_key_openssh
 }
 
 # Leaf - TLS cert request
 output "leaf_cert_request_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_request_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_request_pem
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name" {
-  value = "${module.tls_self_signed_cert.leaf_cert_name}"
+  value = module.tls_self_signed_cert.leaf_cert_name
 }
 
 output "leaf_cert_filename" {
-  value = "${module.tls_self_signed_cert.leaf_cert_filename}"
+  value = module.tls_self_signed_cert.leaf_cert_filename
 }
 
 output "leaf_cert_pem" {
-  value = "${module.tls_self_signed_cert.leaf_cert_pem}"
+  value = module.tls_self_signed_cert.leaf_cert_pem
 }
 
 output "leaf_cert_validity_start_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_start_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_start_time
 }
 
 output "leaf_cert_validity_end_time" {
-  value = "${module.tls_self_signed_cert.leaf_cert_validity_end_time}"
+  value = module.tls_self_signed_cert.leaf_cert_validity_end_time
 }
+

--- a/examples/simple-rsa/terraform.tfvars
+++ b/examples/simple-rsa/terraform.tfvars
@@ -3,5 +3,5 @@ validity_period_hours = "12"
 ca_common_name        = "simple-rsa.com"
 organization_name     = "Simple RSA Inc."
 common_name           = "simple-rsa.com"
-dns_names             = ["simple-rsa.com",]
-ip_addresses          = ["127.0.0.1",]
+dns_names             = ["simple-rsa.com", ]
+ip_addresses          = ["127.0.0.1", ]

--- a/examples/simple-rsa/variables.tf
+++ b/examples/simple-rsa/variables.tf
@@ -1,7 +1,23 @@
-variable "name"                  { }
-variable "validity_period_hours" { }
-variable "ca_common_name"        { }
-variable "organization_name"     { }
-variable "common_name"           { }
-variable "dns_names"             { type = "list" }
-variable "ip_addresses"          { type = "list" }
+variable "name" {
+}
+
+variable "validity_period_hours" {
+}
+
+variable "ca_common_name" {
+}
+
+variable "organization_name" {
+}
+
+variable "common_name" {
+}
+
+variable "dns_names" {
+  type = list(string)
+}
+
+variable "ip_addresses" {
+  type = list(string)
+}
+

--- a/examples/simple-rsa/versions.tf
+++ b/examples/simple-rsa/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/main.tf
+++ b/main.tf
@@ -3,95 +3,101 @@ terraform {
 }
 
 resource "random_id" "name" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
   byte_length = 4
   prefix      = "${var.name}-"
 }
 
 resource "tls_private_key" "ca" {
-  count = "${var.create && !var.ca_override ? 1 : 0}"
+  count = var.create && false == var.ca_override ? 1 : 0
 
-  algorithm   = "${var.algorithm}"
-  ecdsa_curve = "${var.ecdsa_curve}"
-  rsa_bits    = "${var.rsa_bits}"
+  algorithm   = var.algorithm
+  ecdsa_curve = var.ecdsa_curve
+  rsa_bits    = var.rsa_bits
 }
 
 resource "tls_self_signed_cert" "ca" {
-  count = "${var.create && !var.ca_override ? 1 : 0}"
+  count = var.create && false == var.ca_override ? 1 : 0
 
-  key_algorithm     = "${tls_private_key.ca.algorithm}"
-  private_key_pem   = "${var.ca_key_override == "" ? tls_private_key.ca.private_key_pem : var.ca_key_override}"
+  key_algorithm     = tls_private_key.ca[0].algorithm
+  private_key_pem   = var.ca_key_override == "" ? tls_private_key.ca[0].private_key_pem : var.ca_key_override
   is_ca_certificate = true
 
-  validity_period_hours = "${var.validity_period_hours}"
-  allowed_uses          = ["${var.ca_allowed_uses}"]
+  validity_period_hours = var.validity_period_hours
+  allowed_uses          = var.ca_allowed_uses
 
   subject {
-    common_name  = "${var.ca_common_name}"
-    organization = "${var.organization_name}"
+    common_name  = var.ca_common_name
+    organization = var.organization_name
   }
 }
 
 resource "tls_private_key" "leaf" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
-  algorithm   = "${var.algorithm}"
-  ecdsa_curve = "${var.ecdsa_curve}"
-  rsa_bits    = "${var.rsa_bits}"
+  algorithm   = var.algorithm
+  ecdsa_curve = var.ecdsa_curve
+  rsa_bits    = var.rsa_bits
 }
 
 resource "tls_cert_request" "leaf" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
-  key_algorithm   = "${tls_private_key.leaf.algorithm}"
-  private_key_pem = "${tls_private_key.leaf.private_key_pem}"
+  key_algorithm   = tls_private_key.leaf[0].algorithm
+  private_key_pem = tls_private_key.leaf[0].private_key_pem
 
-  dns_names    = ["${var.dns_names}"]
-  ip_addresses = ["${var.ip_addresses}"]
+  dns_names    = var.dns_names
+  ip_addresses = var.ip_addresses
 
   subject {
-    common_name  = "${var.common_name}"
-    organization = "${var.organization_name}"
+    common_name  = var.common_name
+    organization = var.organization_name
   }
 }
 
 resource "tls_locally_signed_cert" "leaf" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
-  cert_request_pem = "${tls_cert_request.leaf.cert_request_pem}"
+  cert_request_pem = tls_cert_request.leaf[0].cert_request_pem
 
-  ca_key_algorithm   = "${!var.ca_override ? element(concat(tls_private_key.ca.*.algorithm, list("")), 0) : var.algorithm}"
-  ca_private_key_pem = "${var.ca_key_override == "" ? element(concat(tls_private_key.ca.*.private_key_pem, list("")), 0) : var.ca_key_override}"
-  ca_cert_pem        = "${var.ca_cert_override == "" ? element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0) : var.ca_cert_override}"
+  ca_key_algorithm   = false == var.ca_override ? element(concat(tls_private_key.ca.*.algorithm, [""]), 0) : var.algorithm
+  ca_private_key_pem = var.ca_key_override == "" ? element(concat(tls_private_key.ca.*.private_key_pem, [""]), 0) : var.ca_key_override
+  ca_cert_pem        = var.ca_cert_override == "" ? element(concat(tls_self_signed_cert.ca.*.cert_pem, [""]), 0) : var.ca_cert_override
 
-  validity_period_hours = "${var.validity_period_hours}"
-  allowed_uses          = ["${var.allowed_uses}"]
+  validity_period_hours = var.validity_period_hours
+  allowed_uses          = var.allowed_uses
 }
 
 resource "null_resource" "download_ca_cert" {
-  count = "${var.create && var.download_certs ? 1 : 0}"
+  count = var.create && var.download_certs ? 1 : 0
 
   # Write the PEM-encoded CA certificate public key to this path (e.g. /etc/tls/ca.crt.pem).
+  # Write the PEM-encoded CA certificate public key to this path (e.g. /etc/tls/ca.crt.pem).
   provisioner "local-exec" {
-    command = "echo '${chomp(var.ca_cert_override == "" ? element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0) : var.ca_cert_override)}' > ${format("%s-ca.crt.pem", random_id.name.hex)} && chmod ${var.permissions} '${format("%s-ca.crt.pem", random_id.name.hex)}'"
+    command = "echo '${chomp(
+      var.ca_cert_override == "" ? element(concat(tls_self_signed_cert.ca.*.cert_pem, [""]), 0) : var.ca_cert_override,
+    )}' > ${format("%s-ca.crt.pem", random_id.name[0].hex)} && chmod ${var.permissions} '${format("%s-ca.crt.pem", random_id.name[0].hex)}'"
   }
 }
 
 resource "null_resource" "download_leaf_cert" {
-  count = "${var.create && var.download_certs ? 1 : 0}"
+  count = var.create && var.download_certs ? 1 : 0
 
   # Write the PEM-encoded certificate public key to this path (e.g. /etc/tls/leaf.crt.pem).
+  # Write the PEM-encoded certificate public key to this path (e.g. /etc/tls/leaf.crt.pem).
   provisioner "local-exec" {
-    command = "echo '${chomp(tls_locally_signed_cert.leaf.cert_pem)}' > ${format("%s-leaf.crt.pem", random_id.name.hex)} && chmod ${var.permissions} '${format("%s-leaf.crt.pem", random_id.name.hex)}'"
+    command = "echo '${chomp(tls_locally_signed_cert.leaf[0].cert_pem)}' > ${format("%s-leaf.crt.pem", random_id.name[0].hex)} && chmod ${var.permissions} '${format("%s-leaf.crt.pem", random_id.name[0].hex)}'"
   }
 }
 
 resource "null_resource" "download_leaf_private_key" {
-  count = "${var.create && var.download_certs ? 1 : 0}"
+  count = var.create && var.download_certs ? 1 : 0
 
   # Write the PEM-encoded leaf certificate private key to this path (e.g. /etc/tls/leaf.key.pem).
+  # Write the PEM-encoded leaf certificate private key to this path (e.g. /etc/tls/leaf.key.pem).
   provisioner "local-exec" {
-    command = "echo '${chomp(tls_private_key.leaf.private_key_pem)}' > ${format("%s-leaf.key.pem", random_id.name.hex)} && chmod ${var.permissions} '${format("%s-leaf.key.pem", random_id.name.hex)}'"
+    command = "echo '${chomp(tls_private_key.leaf[0].private_key_pem)}' > ${format("%s-leaf.key.pem", random_id.name[0].hex)} && chmod ${var.permissions} '${format("%s-leaf.key.pem", random_id.name[0].hex)}'"
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,106 +6,147 @@ output "zREADME" {
 
 The below private keys and self signed TLS certificates have been generated.
 
-- CA certificate: ${element(concat(formatlist("%s-ca", random_id.name.*.hex), list("")), 0)}
-- Leaf certificate: ${element(concat(formatlist("%s-leaf", random_id.name.*.hex), list("")), 0)}
+- CA certificate: ${element(concat(formatlist("%s-ca", random_id.name.*.hex), [""]), 0)}
+- Leaf certificate: ${element(concat(formatlist("%s-leaf", random_id.name.*.hex), [""]), 0)}
 
-${var.download_certs ?
-"The below certificates and private key have been downloaded locally with the
-file permissions updated appropriately.
-
-- ${element(concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), list("")), 0)}
-- ${element(concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), list("")), 0)}
-- ${element(concat(formatlist("%s-leaf.key.pem", random_id.name.*.hex), list("")), 0)}
-
-  # View your certs
-  $ openssl x509 -text -in ${element(concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), list("")), 0)}
-  $ openssl x509 -text -in ${element(concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), list("")), 0)}
-
-  # Verify root CA
-  $ openssl verify -CAfile ${element(concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), list("")), 0)} \\
-    ${element(concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), list("")), 0)}"
-:
-"Certs were not downloaded locally. set \"download_certs\" to true to download."}
+${var.download_certs ? "The below certificates and private key have been downloaded locally with the\nfile permissions updated appropriately.\n\n- ${element(
+  concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
+  0,
+  )}\n- ${element(
+  concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
+  0,
+  )}\n- ${element(
+  concat(formatlist("%s-leaf.key.pem", random_id.name.*.hex), [""]),
+  0,
+  )}\n\n  # View your certs\n  $ openssl x509 -text -in ${element(
+  concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
+  0,
+  )}\n  $ openssl x509 -text -in ${element(
+  concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
+  0,
+  )}\n\n  # Verify root CA\n  $ openssl verify -CAfile ${element(
+  concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
+  0,
+  )} \\\n    ${element(
+  concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
+  0,
+)}" : "Certs were not downloaded locally. set \"download_certs\" to true to download."}
 README
+
 }
 
 output "algorithm" {
-  value = "${var.algorithm}"
+  value = var.algorithm
 }
 
 # CA - TLS private key
 output "ca_private_key_pem" {
-  value = "${chomp(element(concat(tls_private_key.ca.*.private_key_pem, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_private_key.ca.*.private_key_pem, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 output "ca_public_key_pem" {
-  value = "${chomp(element(concat(tls_private_key.ca.*.public_key_pem, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_private_key.ca.*.public_key_pem, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 output "ca_public_key_openssh" {
-  value = "${chomp(element(concat(tls_private_key.ca.*.public_key_openssh, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_private_key.ca.*.public_key_openssh, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name" {
-  value = "${element(concat(formatlist("%s-ca", random_id.name.*.hex), list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(concat(formatlist("%s-ca", random_id.name.*.hex), [""]), 0) # TODO: Workaround for issue #11210
 }
 
 output "ca_cert_filename" {
-  value = "${element(concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(
+    concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
+    0,
+  ) # TODO: Workaround for issue #11210
 }
 
 output "ca_cert_pem" {
-  value = "${chomp(element(concat(tls_self_signed_cert.ca.*.cert_pem, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(element(concat(tls_self_signed_cert.ca.*.cert_pem, [""]), 0)) # TODO: Workaround for issue #11210
 }
 
 output "ca_cert_validity_start_time" {
-  value = "${element(concat(tls_self_signed_cert.ca.*.validity_start_time, list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(
+    concat(tls_self_signed_cert.ca.*.validity_start_time, [""]),
+    0,
+  ) # TODO: Workaround for issue #11210
 }
 
 output "ca_cert_validity_end_time" {
-  value = "${element(concat(tls_self_signed_cert.ca.*.validity_end_time, list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(concat(tls_self_signed_cert.ca.*.validity_end_time, [""]), 0) # TODO: Workaround for issue #11210
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem" {
-  value = "${chomp(element(concat(tls_private_key.leaf.*.private_key_pem, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_private_key.leaf.*.private_key_pem, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 output "leaf_private_key_filename" {
-  value = "${element(concat(formatlist("%s-leaf.key.pem", random_id.name.*.hex), list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(
+    concat(formatlist("%s-leaf.key.pem", random_id.name.*.hex), [""]),
+    0,
+  ) # TODO: Workaround for issue #11210
 }
 
 output "leaf_public_key_pem" {
-  value = "${chomp(element(concat(tls_private_key.leaf.*.public_key_pem, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_private_key.leaf.*.public_key_pem, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 output "leaf_public_key_openssh" {
-  value = "${chomp(element(concat(tls_private_key.leaf.*.public_key_openssh, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_private_key.leaf.*.public_key_openssh, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 # Leaf - TLS cert request
 output "leaf_cert_request_pem" {
-  value = "${chomp(element(concat(tls_cert_request.leaf.*.cert_request_pem, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_cert_request.leaf.*.cert_request_pem, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name" {
-  value = "${element(concat(formatlist("%s-leaf", random_id.name.*.hex), list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(concat(formatlist("%s-leaf", random_id.name.*.hex), [""]), 0) # TODO: Workaround for issue #11210
 }
 
 output "leaf_cert_filename" {
-  value = "${element(concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(
+    concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
+    0,
+  ) # TODO: Workaround for issue #11210
 }
 
 output "leaf_cert_pem" {
-  value = "${chomp(element(concat(tls_locally_signed_cert.leaf.*.cert_pem, list("")), 0))}" # TODO: Workaround for issue #11210
+  value = chomp(
+    element(concat(tls_locally_signed_cert.leaf.*.cert_pem, [""]), 0),
+  ) # TODO: Workaround for issue #11210
 }
 
 output "leaf_cert_validity_start_time" {
-  value = "${element(concat(tls_locally_signed_cert.leaf.*.validity_start_time, list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(
+    concat(tls_locally_signed_cert.leaf.*.validity_start_time, [""]),
+    0,
+  ) # TODO: Workaround for issue #11210
 }
 
 output "leaf_cert_validity_end_time" {
-  value = "${element(concat(tls_locally_signed_cert.leaf.*.validity_end_time, list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(
+    concat(tls_locally_signed_cert.leaf.*.validity_end_time, [""]),
+    0,
+  ) # TODO: Workaround for issue #11210
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,37 +1,33 @@
 output "zREADME" {
-  value = <<README
-# ------------------------------------------------------------------------------
-# ${var.name} TLS Self Signed Certs
-# ------------------------------------------------------------------------------
+  value = <<-README
+  # ------------------------------------------------------------------------------
+  # ${var.name} TLS Self Signed Certs
+  # ------------------------------------------------------------------------------
 
-The below private keys and self signed TLS certificates have been generated.
+  The below private keys and self signed TLS certificates have been generated.
 
-- CA certificate: ${element(concat(formatlist("%s-ca", random_id.name.*.hex), [""]), 0)}
-- Leaf certificate: ${element(concat(formatlist("%s-leaf", random_id.name.*.hex), [""]), 0)}
+  - CA certificate: ${length(random_id.name.*.hex) > 0 ? format("%s-ca", random_id.name.*.hex[0]) : ""}
+  - Leaf certificate: ${length(random_id.name.*.hex) > 0 ? format("%s-leaf", random_id.name.*.hex[0]) : ""}
 
-${var.download_certs ? "The below certificates and private key have been downloaded locally with the\nfile permissions updated appropriately.\n\n- ${element(
-  concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
-  0,
-  )}\n- ${element(
-  concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
-  0,
-  )}\n- ${element(
-  concat(formatlist("%s-leaf.key.pem", random_id.name.*.hex), [""]),
-  0,
-  )}\n\n  # View your certs\n  $ openssl x509 -text -in ${element(
-  concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
-  0,
-  )}\n  $ openssl x509 -text -in ${element(
-  concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
-  0,
-  )}\n\n  # Verify root CA\n  $ openssl verify -CAfile ${element(
-  concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
-  0,
-  )} \\\n    ${element(
-  concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
-  0,
-)}" : "Certs were not downloaded locally. set \"download_certs\" to true to download."}
-README
+  %{if var.download_certs~}
+  The below certificates and private key have been downloaded locally with the
+  file permissions updated appropriately.
+
+  - ${length(random_id.name.*.hex) > 0 ? format("%s-ca.crt.pem", random_id.name.*.hex[0]) : ""}
+  - ${length(random_id.name.*.hex) > 0 ? format("%s-leaf.crt.pem", random_id.name.*.hex[0]) : ""}
+  - ${length(random_id.name.*.hex) > 0 ? format("%s-leaf.key.pem", random_id.name.*.hex[0]) : ""}
+
+    # View your certs
+    $ openssl x509 -text -in ${length(random_id.name.*.hex) > 0 ? format("%s-ca.crt.pem", random_id.name.*.hex[0]) : ""}
+    $ openssl x509 -text -in ${length(random_id.name.*.hex) > 0 ? format("%s-leaf.crt.pem", random_id.name.*.hex[0]) : ""}
+
+    # Verify root CA
+    $ openssl verify -CAfile ${length(random_id.name.*.hex) > 0 ? format("%s-ca.crt.pem", random_id.name.*.hex[0]) : ""} \
+      ${length(random_id.name.*.hex) > 0 ? format("%s-leaf.crt.pem", random_id.name.*.hex[0]) : ""}
+  %{else~}
+  Certs were not downloaded locally. set "download_certs" to true to download.
+  %{endif~}
+  README
 
 }
 
@@ -41,112 +37,75 @@ output "algorithm" {
 
 # CA - TLS private key
 output "ca_private_key_pem" {
-  value = chomp(
-    element(concat(tls_private_key.ca.*.private_key_pem, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_private_key.ca.*.private_key_pem) > 0 ? tls_private_key.ca.*.private_key_pem[0] : ""
 }
-
 output "ca_public_key_pem" {
-  value = chomp(
-    element(concat(tls_private_key.ca.*.public_key_pem, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_private_key.ca.*.public_key_pem) > 0 ? tls_private_key.ca.*.public_key_pem[0] : ""
 }
-
 output "ca_public_key_openssh" {
-  value = chomp(
-    element(concat(tls_private_key.ca.*.public_key_openssh, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_private_key.ca.*.public_key_openssh) > 0 ? tls_private_key.ca.*.public_key_openssh[0] : ""
+
 }
 
 # CA - TLS self signed cert
 output "ca_cert_name" {
-  value = element(concat(formatlist("%s-ca", random_id.name.*.hex), [""]), 0) # TODO: Workaround for issue #11210
+  value = length(random_id.name.*.hex) > 0 ? formatlist("%s-ca", random_id.name.*.hex)[0] : ""
 }
 
 output "ca_cert_filename" {
-  value = element(
-    concat(formatlist("%s-ca.crt.pem", random_id.name.*.hex), [""]),
-    0,
-  ) # TODO: Workaround for issue #11210
+  value = length(random_id.name.*.hex) > 0 ? format("%s-ca.crt.pem", random_id.name.*.hex[0]) : ""
 }
 
 output "ca_cert_pem" {
-  value = chomp(element(concat(tls_self_signed_cert.ca.*.cert_pem, [""]), 0)) # TODO: Workaround for issue #11210
+  value = length(tls_self_signed_cert.ca.*.cert_pem) > 0 ? tls_self_signed_cert.ca.*.cert_pem[0] : ""
 }
 
 output "ca_cert_validity_start_time" {
-  value = element(
-    concat(tls_self_signed_cert.ca.*.validity_start_time, [""]),
-    0,
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_self_signed_cert.ca.*.validity_start_time) > 0 ? tls_self_signed_cert.ca.*.validity_start_time[0] : ""
 }
 
 output "ca_cert_validity_end_time" {
-  value = element(concat(tls_self_signed_cert.ca.*.validity_end_time, [""]), 0) # TODO: Workaround for issue #11210
+  value = length(tls_self_signed_cert.ca.*.validity_end_time) > 0 ? tls_self_signed_cert.ca.*.validity_end_time[0] : ""
 }
 
 # Leaf - TLS private key
 output "leaf_private_key_pem" {
-  value = chomp(
-    element(concat(tls_private_key.leaf.*.private_key_pem, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_private_key.leaf.*.private_key_pem) > 0 ? tls_private_key.leaf.*.private_key_pem[0] : ""
 }
 
 output "leaf_private_key_filename" {
-  value = element(
-    concat(formatlist("%s-leaf.key.pem", random_id.name.*.hex), [""]),
-    0,
-  ) # TODO: Workaround for issue #11210
+  value = length(random_id.name.*.hex) > 0 ? format("%s-leaf.key.pem", random_id.name.*.hex[0]) : ""
 }
 
 output "leaf_public_key_pem" {
-  value = chomp(
-    element(concat(tls_private_key.leaf.*.public_key_pem, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_private_key.leaf.*.public_key_pem) > 0 ? tls_private_key.leaf.*.public_key_pem[0] : ""
 }
 
 output "leaf_public_key_openssh" {
-  value = chomp(
-    element(concat(tls_private_key.leaf.*.public_key_openssh, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_private_key.leaf.*.public_key_openssh) > 0 ? tls_private_key.leaf.*.public_key_openssh[0] : ""
 }
 
-# Leaf - TLS cert request
 output "leaf_cert_request_pem" {
-  value = chomp(
-    element(concat(tls_cert_request.leaf.*.cert_request_pem, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_cert_request.leaf.*.cert_request_pem) > 0 ? tls_cert_request.leaf.*.cert_request_pem[0] : ""
 }
 
 # Leaf - TLS locally signed cert
 output "leaf_cert_name" {
-  value = element(concat(formatlist("%s-leaf", random_id.name.*.hex), [""]), 0) # TODO: Workaround for issue #11210
+  value = length(random_id.name.*.hex) > 0 ? format("%s-leaf", random_id.name.*.hex[0]) : ""
 }
 
 output "leaf_cert_filename" {
-  value = element(
-    concat(formatlist("%s-leaf.crt.pem", random_id.name.*.hex), [""]),
-    0,
-  ) # TODO: Workaround for issue #11210
+  value = length(random_id.name.*.hex) > 0 ? format("%s-leaf.crt.pem", random_id.name.*.hex[0]) : ""
 }
 
 output "leaf_cert_pem" {
-  value = chomp(
-    element(concat(tls_locally_signed_cert.leaf.*.cert_pem, [""]), 0),
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_locally_signed_cert.leaf.*.cert_pem) > 0 ? tls_locally_signed_cert.leaf.*.cert_pem[0] : ""
 }
 
 output "leaf_cert_validity_start_time" {
-  value = element(
-    concat(tls_locally_signed_cert.leaf.*.validity_start_time, [""]),
-    0,
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_locally_signed_cert.leaf.*.validity_start_time) > 0 ? tls_locally_signed_cert.leaf.*.validity_start_time[0] : ""
 }
 
 output "leaf_cert_validity_end_time" {
-  value = element(
-    concat(tls_locally_signed_cert.leaf.*.validity_end_time, [""]),
-    0,
-  ) # TODO: Workaround for issue #11210
+  value = length(tls_locally_signed_cert.leaf.*.validity_end_time) > 0 ? tls_locally_signed_cert.leaf.*.validity_end_time[0] : ""
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "validity_period_hours" {
 
 variable "ca_allowed_uses" {
   description = "List of keywords from RFC5280 describing a use that is permitted for the CA certificate. For more info and the list of keywords, see https://www.terraform.io/docs/providers/tls/r/self_signed_cert.html#allowed_uses."
-  type        = "list"
+  type        = list(string)
 
   default = [
     "cert_signing",
@@ -54,7 +54,7 @@ variable "organization_name" {
 
 variable "allowed_uses" {
   description = "List of keywords from RFC5280 describing a use that is permitted for the issued certificate. For more info and the list of keywords, see https://www.terraform.io/docs/providers/tls/r/self_signed_cert.html#allowed_uses."
-  type        = "list"
+  type        = list(string)
 
   default = [
     "key_encipherment",
@@ -68,13 +68,13 @@ variable "common_name" {
 
 variable "dns_names" {
   description = "List of DNS names for which the certificate will be valid (e.g. foo.hashicorp.com), defaults to empty list."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ip_addresses" {
   description = "List of IP addresses for which the certificate will be valid (e.g. 127.0.0.1), defaults to empty list."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
@@ -97,3 +97,4 @@ variable "download_certs" {
   description = "Download certs locally, defaults to false."
   default     = false
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
1. Applied `terraform 0.12upgrade` to main module and all examples.
2. Rework `outputs.tf` for 0.12 features.

Addresses https://github.com/hashicorp-modules/tls-self-signed-cert/issues/4

Also ran all of the examples and they appear to be working as expected.